### PR TITLE
github-pages-template disabled-void-style.

### DIFF
--- a/test/build-html-validate.mjs
+++ b/test/build-html-validate.mjs
@@ -16,8 +16,6 @@ const htmlValidate = new HtmlValidate({
     "latest-packages": "error",
     "https-links": "error",
     "internal-links": "error",
-  },
-  "rules": {
     "void-style": "off"
   }
 });


### PR DESCRIPTION
Due to https://github.com/fulldecent/github-pages-template/commit/038729c95abd285e84e38edcfb6edc249b9f1fa7 our custom rules stopped working. I added the instruction to disable `void-style` in our existing rule, and it worked without disturbing our existing custom tests.