### PR TITLE
Add cache URL count after restore cache action

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -81,6 +81,10 @@ jobs:
         with:
           path: cache/
           key: test-cache
+      - name: Count URLs in cache
+        run: |
+          URL_COUNT=$(sqlite3 cache/external-links.db "SELECT COUNT(*) FROM urls;")
+          echo "Number of URLs in cache: $URL_COUNT"
       - name: Test suite
         run: yarn run test
       - name: Save testing cache


### PR DESCRIPTION
Fixes #108

Add a step to count and print the number of URLs in the cache after the restore cache action.

* Add a new step in the `test` job in the `.github/workflows/build-test-deploy.yml` file to count and print the number of URLs in the cache SQLite database.
* Use a shell command to count the number of URLs in the `cache/external-links.db` database and print the count.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fulldecent/github-pages-template/pull/114?shareId=0fdefeeb-52ac-4a9d-b90d-4c1e88ec4380).